### PR TITLE
Documenting LSTM options

### DIFF
--- a/02_train/src/A_FitBasicLSTM_GPU.ipynb
+++ b/02_train/src/A_FitBasicLSTM_GPU.ipynb
@@ -1,0 +1,535 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "44bbacd6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "#import matplotlib.pyplot as plt\n",
+    "import torch\n",
+    "import torch.nn as nn"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed377b8a",
+   "metadata": {},
+   "source": [
+    "# Configuration"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9aeb3c23",
+   "metadata": {},
+   "source": [
+    "### Inputs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "a79e8db4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "process_out_dir = '01_process/out/'\n",
+    "\n",
+    "train_data_fpath = process_out_dir + 'train_data.npz'\n",
+    "valid_data_fpath = process_out_dir + 'valid_data.npz'\n",
+    "# not doing any test set stuff until the very, very end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "97bc3c61-8615-4602-8846-80501adf72ab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "extended_dir = '/caldera/projects/usgs/water/iidd/datasci/lake-temp/lake_ice_prediction/'\n",
+    "\n",
+    "process_out_dir = extended_dir + process_out_dir\n",
+    "\n",
+    "train_data_fpath = extended_dir + train_data_fpath\n",
+    "valid_data_fpath = extended_dir + valid_data_fpath"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09a0168d",
+   "metadata": {},
+   "source": [
+    "### Values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "a9bf17fb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "epochs = 10000\n",
+    "\n",
+    "# plotting parameters\n",
+    "loss_curve_zoom_ymax = 0.15\n",
+    "loss_curve_zoom_ymin = 0.055"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6f577fe",
+   "metadata": {},
+   "source": [
+    "### Outputs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "6854d8f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_out_dir = '02_train/out/'\n",
+    "\n",
+    "data_scalars_fpath =  train_out_dir + 'limitted_lstm_min_max_scalars.pt'\n",
+    "model_weights_fpath = train_out_dir + 'limitted_lstm_weights.pth'\n",
+    "train_predictions_fpath = train_out_dir + 'limitted_lstm_train_preds.npy'\n",
+    "valid_predictions_fpath = train_out_dir + 'limitted_lstm_valid_preds.npy'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "9d29968e-bd13-4f26-a0e3-840a50ece4c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_scalars_fpath = extended_dir + data_scalars_fpath\n",
+    "model_weights_fpath = extended_dir + model_weights_fpath\n",
+    "train_predictions_fpath = extended_dir + train_predictions_fpath\n",
+    "valid_predictions_fpath = extended_dir + valid_predictions_fpath\n",
+    "#loss_lists_fpath = extended_dir + loss_lists_fpath"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36116278",
+   "metadata": {},
+   "source": [
+    "# Import"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "8888eb01",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_data = np.load(train_data_fpath, allow_pickle = True)\n",
+    "valid_data = np.load(valid_data_fpath, allow_pickle = True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "3d636fdd",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['x', 'y', 'dates', 'DOW', 'features']"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "train_data.files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "a617f12c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_x = train_data['x']\n",
+    "train_y = train_data['y']\n",
+    "train_dates = train_data['dates']\n",
+    "train_DOW = train_data['DOW']\n",
+    "train_variables = train_data['features']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "68494e51",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "valid_x = valid_data['x']\n",
+    "valid_y = valid_data['y']\n",
+    "valid_dates = valid_data['dates']\n",
+    "valid_DOW = valid_data['DOW']\n",
+    "valid_variables = valid_data['features']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec1dae21",
+   "metadata": {},
+   "source": [
+    "### Quick view of all the target sequences"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "132ccc63-7aea-40db-9753-2140bdf8ea11",
+   "metadata": {},
+   "source": [
+    "plt.plot(np.moveaxis(train_y, 0, 1), color = 'black', alpha = 0.01, label = 'obs')\n",
+    "plt.plot(np.mean(train_y, 0), label = 'avg obs', color = 'cyan')\n",
+    "plt.yticks([0, 1], ['No', 'Yes'])\n",
+    "plt.ylabel('Ice present?')\n",
+    "plt.xlabel('Days after July 1st');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "61388316",
+   "metadata": {},
+   "source": [
+    "# Prepare data for `torch`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "f7708b8c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_y = torch.from_numpy(train_y).float().unsqueeze(2) # adding a feature dimension to Ys\n",
+    "train_x = torch.from_numpy(train_x).float()\n",
+    "\n",
+    "valid_y = torch.from_numpy(valid_y).float().unsqueeze(2)\n",
+    "valid_x = torch.from_numpy(valid_x).float()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9918e72d",
+   "metadata": {},
+   "source": [
+    "# min-max scale the data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "11139b2e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "min_max_scalars = torch.zeros(train_x.shape[2], 2)\n",
+    "\n",
+    "for i in range(train_x.shape[2]):\n",
+    "    min_max_scalars[i, 0] = train_x[:, :, i].min()\n",
+    "    min_max_scalars[i, 1] = train_x[:, :, i].max()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "e846557e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i in range(train_x.shape[2]):\n",
+    "    # scale train set with train min/max\n",
+    "    train_x[:, :, i] = ((train_x[:, :, i] - min_max_scalars[i, 0]) /\n",
+    "                        (min_max_scalars[i, 1] - min_max_scalars[i, 0]))\n",
+    "    # scale valid set with train min/max\n",
+    "    valid_x[:, :, i] = ((valid_x[:, :, i] - min_max_scalars[i, 0]) /\n",
+    "                        (min_max_scalars[i, 1] - min_max_scalars[i, 0]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2924bb9e",
+   "metadata": {},
+   "source": [
+    "# Define a simple model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "0545b469",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# recycled model code\n",
+    "class LSTMDA(nn.Module):\n",
+    "    def __init__(self, input_dim, hidden_dim, recur_dropout = 0, dropout = 0):\n",
+    "        super().__init__()\n",
+    "        \n",
+    "        self.input_dim = input_dim\n",
+    "        self.hidden_size = hidden_dim\n",
+    "        self.weight_ih = nn.Parameter(torch.Tensor(input_dim, hidden_dim * 4))\n",
+    "        self.weight_hh = nn.Parameter(torch.Tensor(hidden_dim, hidden_dim * 4))\n",
+    "        self.bias = nn.Parameter(torch.Tensor(hidden_dim * 4))\n",
+    "        self.init_weights()\n",
+    "        \n",
+    "        self.dropout = nn.Dropout(dropout)\n",
+    "        self.recur_dropout = nn.Dropout(recur_dropout)\n",
+    "        \n",
+    "        self.dense = nn.Linear(hidden_dim, 1)\n",
+    "        self.dense_activation = nn.Sigmoid()\n",
+    "    \n",
+    "    def init_weights(self):\n",
+    "        for p in self.parameters():\n",
+    "            if p.data.ndimension() >= 2:\n",
+    "                nn.init.xavier_uniform_(p.data)\n",
+    "            else:\n",
+    "                nn.init.zeros_(p.data)\n",
+    "        \n",
+    "    def forward(self, x, init_states = None):\n",
+    "        \"\"\"Assumes x is of shape (batch, sequence, feature)\"\"\"\n",
+    "        bs, seq_sz, _ = x.size()\n",
+    "        hidden_seq = []\n",
+    "        if init_states is None:\n",
+    "            h_t, c_t = (torch.zeros(bs, self.hidden_size).to(x.device), \n",
+    "                        torch.zeros(bs, self.hidden_size).to(x.device))\n",
+    "        else:\n",
+    "            h_t, c_t = init_states\n",
+    "        \n",
+    "        x = self.dropout(x)\n",
+    "        HS = self.hidden_size\n",
+    "        for t in range(seq_sz):\n",
+    "            x_t = x[:, t, :]\n",
+    "            # batch the computations into a single matrix multiplication\n",
+    "            gates = x_t @ self.weight_ih + h_t @ self.weight_hh + self.bias\n",
+    "            i_t, f_t, g_t, o_t = (\n",
+    "                torch.sigmoid(gates[:, :HS]), # input\n",
+    "                torch.sigmoid(gates[:, HS:HS*2]), # forget\n",
+    "                torch.tanh(gates[:, HS*2:HS*3]),\n",
+    "                torch.sigmoid(gates[:, HS*3:]), # output\n",
+    "            )\n",
+    "            c_t = f_t * c_t + i_t * self.recur_dropout(g_t)\n",
+    "            h_t = o_t * torch.tanh(c_t)\n",
+    "            hidden_seq.append(h_t.unsqueeze(1))\n",
+    "        hidden_seq = torch.cat(hidden_seq, dim= 1)\n",
+    "        out = self.dense_activation(self.dense(hidden_seq))\n",
+    "        \n",
+    "        return out, (h_t, c_t)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "9d4b0163",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# initialize the model with a seed\n",
+    "torch.manual_seed(0)\n",
+    "\n",
+    "# very small model\n",
+    "# maps 13 variables to hidden dim of 1 via LSTM layer\n",
+    "# transforms that LSTM out with a dense layer (scale and bias)\n",
+    "# then sigmoid activation for probability\n",
+    "model = LSTMDA(11, 1).cuda()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d894b020",
+   "metadata": {},
+   "source": [
+    "# Training"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1fdb1837",
+   "metadata": {},
+   "source": [
+    "### Train loop"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "289310a0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0 0.6976397633552551\n",
+      "1000 0.2334420084953308\n",
+      "2000 0.14772184193134308\n",
+      "3000 0.10554295778274536\n",
+      "4000 0.08626815676689148\n",
+      "5000 0.07577812671661377\n",
+      "6000 0.06888356804847717\n",
+      "7000 0.06474336981773376\n",
+      "8000 0.06207174062728882\n",
+      "9000 0.06020260602235794\n",
+      "10000 0.059035032987594604\n"
+     ]
+    }
+   ],
+   "source": [
+    "loss_fn = torch.nn.BCELoss()\n",
+    "loss_ls = []\n",
+    "valid_loss_ls = []\n",
+    "\n",
+    "optimizer = torch.optim.Adam(model.parameters())\n",
+    "for i in range(epochs):\n",
+    "    train_y_hat, (h, c) = model(train_x.cuda())\n",
+    "    loss = loss_fn(train_y_hat, train_y.cuda())\n",
+    "    optimizer.zero_grad()\n",
+    "    loss.backward()\n",
+    "    optimizer.step()\n",
+    "    loss_ls.append(loss.item())\n",
+    "    \n",
+    "    if i % int(epochs / 10) == 0:\n",
+    "        print(i, loss.item())\n",
+    "        \n",
+    "    with torch.no_grad():\n",
+    "        valid_y_hat, (h, c) = model(valid_x.cuda())\n",
+    "        valid_loss = loss_fn(valid_y_hat, valid_y.cuda())\n",
+    "        valid_loss_ls.append(valid_loss.item())\n",
+    "        \n",
+    "print(epochs, loss.item())"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "b1b9a20a-c87f-454b-92a9-6fe70bde87c6",
+   "metadata": {},
+   "source": [
+    "fig, ax = plt.subplots(1, 2, figsize = (12, 6))\n",
+    "\n",
+    "ax[0].axhline(loss_curve_zoom_ymax, color = 'black', linestyle = '--',\n",
+    "              label = 'zoomed-in bound')\n",
+    "ax[0].axhline(loss_curve_zoom_ymin, color = 'black', linestyle = '--')\n",
+    "ax[0].plot(loss_ls, label = 'train')\n",
+    "ax[0].plot(valid_loss_ls, label = 'valid')\n",
+    "ax[0].set_title('Full loss curves')\n",
+    "ax[0].legend()\n",
+    "\n",
+    "ax[1].plot(loss_ls, label = 'train')\n",
+    "ax[1].plot(valid_loss_ls, label = 'valid')\n",
+    "ax[1].set_ylim(loss_curve_zoom_ymin, loss_curve_zoom_ymax)\n",
+    "ax[1].set_title('Zoomed-in loss curves')\n",
+    "ax[1].legend();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d11b6cf",
+   "metadata": {},
+   "source": [
+    "# Save predictions for evaluation\n",
+    "\n",
+    "To save on file size, I'm not going to rebundle the other objects, they can be combined later with a simple concatenate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "c88b5638",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_y_hat, (h, c) = model(train_x.cuda())\n",
+    "valid_y_hat, (h, c) = model(valid_x.cuda())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "7dba4677",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_y_hat = train_y_hat.detach().cpu().numpy()\n",
+    "valid_y_hat = valid_y_hat.detach().cpu().numpy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "6ed8b116",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.save(train_predictions_fpath, train_y_hat)\n",
+    "np.save(valid_predictions_fpath, valid_y_hat)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23aeeada",
+   "metadata": {},
+   "source": [
+    "# Save model weights and min-max scalars"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "0f9dacd8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "torch.save(min_max_scalars, data_scalars_fpath)\n",
+    "torch.save(model.state_dict(), model_weights_fpath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20800b7a-c51d-4c35-bafe-469e8ea2bf13",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python/3.10",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/02_train/src/A_FitBasicTorchNNLSTM_GPU.ipynb
+++ b/02_train/src/A_FitBasicTorchNNLSTM_GPU.ipynb
@@ -1,0 +1,542 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "44bbacd6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "#import matplotlib.pyplot as plt\n",
+    "import torch\n",
+    "import torch.nn as nn"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed377b8a",
+   "metadata": {},
+   "source": [
+    "# Configuration"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9aeb3c23",
+   "metadata": {},
+   "source": [
+    "### Inputs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "a79e8db4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "process_out_dir = '01_process/out/'\n",
+    "\n",
+    "train_data_fpath = process_out_dir + 'train_data.npz'\n",
+    "valid_data_fpath = process_out_dir + 'valid_data.npz'\n",
+    "# not doing any test set stuff until the very, very end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "97bc3c61-8615-4602-8846-80501adf72ab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "extended_dir = '/caldera/projects/usgs/water/iidd/datasci/lake-temp/lake_ice_prediction/'\n",
+    "\n",
+    "process_out_dir = extended_dir + process_out_dir\n",
+    "\n",
+    "train_data_fpath = extended_dir + train_data_fpath\n",
+    "valid_data_fpath = extended_dir + valid_data_fpath"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09a0168d",
+   "metadata": {},
+   "source": [
+    "### Values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a9bf17fb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "epochs = 10000\n",
+    "\n",
+    "# plotting parameters\n",
+    "loss_curve_zoom_ymax = 0.15\n",
+    "loss_curve_zoom_ymin = 0.055"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6f577fe",
+   "metadata": {},
+   "source": [
+    "### Outputs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "6854d8f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_out_dir = '02_train/out/'\n",
+    "\n",
+    "data_scalars_fpath =  train_out_dir + 'limitted_nn_lstm_min_max_scalars.pt'\n",
+    "model_weights_fpath = train_out_dir + 'limitted_nn_lstm_weights.pth'\n",
+    "train_predictions_fpath = train_out_dir + 'limitted_nn_lstm_train_preds.npy'\n",
+    "valid_predictions_fpath = train_out_dir + 'limitted_nn_lstm_valid_preds.npy'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "9d29968e-bd13-4f26-a0e3-840a50ece4c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_scalars_fpath = extended_dir + data_scalars_fpath\n",
+    "model_weights_fpath = extended_dir + model_weights_fpath\n",
+    "train_predictions_fpath = extended_dir + train_predictions_fpath\n",
+    "valid_predictions_fpath = extended_dir + valid_predictions_fpath\n",
+    "#loss_lists_fpath = extended_dir + loss_lists_fpath"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36116278",
+   "metadata": {},
+   "source": [
+    "# Import"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "8888eb01",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_data = np.load(train_data_fpath, allow_pickle = True)\n",
+    "valid_data = np.load(valid_data_fpath, allow_pickle = True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "3d636fdd",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['x', 'y', 'dates', 'DOW', 'features']"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "train_data.files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "a617f12c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_x = train_data['x']\n",
+    "train_y = train_data['y']\n",
+    "train_dates = train_data['dates']\n",
+    "train_DOW = train_data['DOW']\n",
+    "train_variables = train_data['features']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "68494e51",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "valid_x = valid_data['x']\n",
+    "valid_y = valid_data['y']\n",
+    "valid_dates = valid_data['dates']\n",
+    "valid_DOW = valid_data['DOW']\n",
+    "valid_variables = valid_data['features']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec1dae21",
+   "metadata": {},
+   "source": [
+    "### Quick view of all the target sequences"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "132ccc63-7aea-40db-9753-2140bdf8ea11",
+   "metadata": {},
+   "source": [
+    "plt.plot(np.moveaxis(train_y, 0, 1), color = 'black', alpha = 0.01, label = 'obs')\n",
+    "plt.plot(np.mean(train_y, 0), label = 'avg obs', color = 'cyan')\n",
+    "plt.yticks([0, 1], ['No', 'Yes'])\n",
+    "plt.ylabel('Ice present?')\n",
+    "plt.xlabel('Days after July 1st');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "61388316",
+   "metadata": {},
+   "source": [
+    "# Prepare data for `torch`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "f7708b8c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_y = torch.from_numpy(train_y).float().unsqueeze(2) # adding a feature dimension to Ys\n",
+    "train_x = torch.from_numpy(train_x).float()\n",
+    "\n",
+    "valid_y = torch.from_numpy(valid_y).float().unsqueeze(2)\n",
+    "valid_x = torch.from_numpy(valid_x).float()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9918e72d",
+   "metadata": {},
+   "source": [
+    "# min-max scale the data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "11139b2e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "min_max_scalars = torch.zeros(train_x.shape[2], 2)\n",
+    "\n",
+    "for i in range(train_x.shape[2]):\n",
+    "    min_max_scalars[i, 0] = train_x[:, :, i].min()\n",
+    "    min_max_scalars[i, 1] = train_x[:, :, i].max()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "e846557e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i in range(train_x.shape[2]):\n",
+    "    # scale train set with train min/max\n",
+    "    train_x[:, :, i] = ((train_x[:, :, i] - min_max_scalars[i, 0]) /\n",
+    "                        (min_max_scalars[i, 1] - min_max_scalars[i, 0]))\n",
+    "    # scale valid set with train min/max\n",
+    "    valid_x[:, :, i] = ((valid_x[:, :, i] - min_max_scalars[i, 0]) /\n",
+    "                        (min_max_scalars[i, 1] - min_max_scalars[i, 0]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2924bb9e",
+   "metadata": {},
+   "source": [
+    "# Define a simple model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "0545b469",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# recycled model code\n",
+    "class LSTMDA(nn.Module):\n",
+    "    def __init__(self, input_dim, hidden_dim, dropout = 0):\n",
+    "        super().__init__()\n",
+    "        \n",
+    "        self.lstm = nn.LSTM(input_dim, hidden_dim, dropout = dropout,\n",
+    "                            batch_first = True) # PROJECT LEVEL DESIGN\n",
+    "        \n",
+    "        self.dense = nn.Linear(hidden_dim, 1)\n",
+    "        self.dense_activation = nn.Sigmoid()\n",
+    "        \n",
+    "    def forward(self, x):\n",
+    "        \"\"\"Assumes x is of shape (batch, sequence, feature)\"\"\"\n",
+    "       \n",
+    "        lstm_out, (h, c) = self.lstm(x)\n",
+    "        out = self.dense_activation(self.dense(lstm_out))\n",
+    "        \n",
+    "        return out"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "9d4b0163",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# initialize the model with a seed\n",
+    "torch.manual_seed(0)\n",
+    "\n",
+    "# very small model\n",
+    "# maps 13 variables to hidden dim of 1 via LSTM layer\n",
+    "# transforms that LSTM out with a dense layer (scale and bias)\n",
+    "# then sigmoid activation for probability\n",
+    "model = LSTMDA(11, 1).cuda()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d894b020",
+   "metadata": {},
+   "source": [
+    "# Training"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1fdb1837",
+   "metadata": {},
+   "source": [
+    "### Train loop"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "289310a0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0 0.6655966639518738\n",
+      "1000 0.24757108092308044\n",
+      "2000 0.15258921682834625\n",
+      "3000 0.10675746202468872\n",
+      "4000 0.08650056272745132\n",
+      "5000 0.07551487535238266\n",
+      "6000 0.06892869621515274\n",
+      "7000 0.064667709171772\n",
+      "8000 0.06175287067890167\n",
+      "9000 0.06013138219714165\n",
+      "10000 0.05909085273742676\n",
+      "CPU times: user 6min 5s, sys: 23.3 s, total: 6min 29s\n",
+      "Wall time: 6min 44s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "loss_fn = torch.nn.BCELoss()\n",
+    "loss_ls = []\n",
+    "valid_loss_ls = []\n",
+    "\n",
+    "optimizer = torch.optim.Adam(model.parameters())\n",
+    "for i in range(epochs):\n",
+    "    train_y_hat = model(train_x.cuda())\n",
+    "    loss = loss_fn(train_y_hat, train_y.cuda())\n",
+    "    optimizer.zero_grad()\n",
+    "    loss.backward()\n",
+    "    optimizer.step()\n",
+    "    loss_ls.append(loss.item())\n",
+    "    \n",
+    "    if i % int(epochs / 10) == 0:\n",
+    "        print(i, loss.item())\n",
+    "        \n",
+    "    with torch.no_grad():\n",
+    "        valid_y_hat = model(valid_x.cuda())\n",
+    "        valid_loss = loss_fn(valid_y_hat, valid_y.cuda())\n",
+    "        valid_loss_ls.append(valid_loss.item())\n",
+    "        \n",
+    "print(epochs, loss.item())"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "b1b9a20a-c87f-454b-92a9-6fe70bde87c6",
+   "metadata": {},
+   "source": [
+    "fig, ax = plt.subplots(1, 2, figsize = (12, 6))\n",
+    "\n",
+    "ax[0].axhline(loss_curve_zoom_ymax, color = 'black', linestyle = '--',\n",
+    "              label = 'zoomed-in bound')\n",
+    "ax[0].axhline(loss_curve_zoom_ymin, color = 'black', linestyle = '--')\n",
+    "ax[0].plot(loss_ls, label = 'train')\n",
+    "ax[0].plot(valid_loss_ls, label = 'valid')\n",
+    "ax[0].set_title('Full loss curves')\n",
+    "ax[0].legend()\n",
+    "\n",
+    "ax[1].plot(loss_ls, label = 'train')\n",
+    "ax[1].plot(valid_loss_ls, label = 'valid')\n",
+    "ax[1].set_ylim(loss_curve_zoom_ymin, loss_curve_zoom_ymax)\n",
+    "ax[1].set_title('Zoomed-in loss curves')\n",
+    "ax[1].legend();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d11b6cf",
+   "metadata": {},
+   "source": [
+    "# Save predictions for evaluation\n",
+    "\n",
+    "To save on file size, I'm not going to rebundle the other objects, they can be combined later with a simple concatenate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "c88b5638",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_y_hat = model(train_x.cuda())\n",
+    "valid_y_hat = model(valid_x.cuda())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "7dba4677",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_y_hat = train_y_hat.detach().cpu().numpy()\n",
+    "valid_y_hat = valid_y_hat.detach().cpu().numpy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "6ed8b116",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.save(train_predictions_fpath, train_y_hat)\n",
+    "np.save(valid_predictions_fpath, valid_y_hat)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23aeeada",
+   "metadata": {},
+   "source": [
+    "# Save model weights and min-max scalars"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "0f9dacd8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "torch.save(min_max_scalars, data_scalars_fpath)\n",
+    "torch.save(model.state_dict(), model_weights_fpath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "20800b7a-c51d-4c35-bafe-469e8ea2bf13",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0 0.6610182523727417\n",
+      "1000 0.24859009683132172\n",
+      "2000 0.15261214971542358\n",
+      "3000 0.10815349221229553\n",
+      "4000 0.08829427510499954\n",
+      "5000 0.07753383368253708\n",
+      "6000 0.0711306557059288\n",
+      "7000 0.06706433743238449\n",
+      "8000 0.06418035924434662\n",
+      "9000 0.06259708851575851\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "0.06161261349916458"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "for i in np.arange(0, 10000, 1000):\n",
+    "    print(int(i), valid_loss_ls[int(i)])\n",
+    "valid_loss_ls[-1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "66afeabc-9fec-4c96-a8a9-7216876e97da",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python/3.10",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Quick demo that GPU is an option that has nearly identical training.

Likewise, the default `torch.nn.LSTM` is too and it is much faster, approximately 10x faster for the demonstrated hyperparameters while having very, very similar training.

Moving forward, I'm going to use `torch.nn.LSTM` rather than the other implementation (whose primary benefit was mimicking tensorflow's recurrent dropout functionality for people wanting a `torch` version of `river-dl`)