### PR TITLE
Soft test set

### DIFF
--- a/01_process/src/C_TrainTestSplits.ipynb
+++ b/01_process/src/C_TrainTestSplits.ipynb
@@ -105,12 +105,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "fcd8a3e3",
+   "id": "e118f8c0",
    "metadata": {},
    "outputs": [],
    "source": [
     "train_data_fpath = out_dir + 'train_data.npz'\n",
     "valid_data_fpath = out_dir + 'valid_data.npz'\n",
+    "soft_test_data_fpath = out_dir + 'soft_test_data.npz'\n",
     "test_data_fpath = out_dir + 'test_data.npz'"
    ]
   },
@@ -930,7 +931,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Wall time: 9min 36s\n"
+      "Wall time: 8min 59s\n"
      ]
     }
    ],
@@ -1073,12 +1074,36 @@
   {
    "cell_type": "code",
    "execution_count": 30,
+   "id": "3347c32a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "soft_test_indices = []\n",
+    "for i in df.index:\n",
+    "    if (i not in train_df.index) and (i not in valid_df.index) and (i not in test_df.index):\n",
+    "        soft_test_indices.append(i)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "1cfba06a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert (len(soft_test_indices) + train_df.shape[0] + valid_df.shape[0] + test_df.shape[0]) == df.shape[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
    "id": "9f9a8cf8",
    "metadata": {},
    "outputs": [],
    "source": [
     "save_partition_data(train_df.index, train_data_fpath)\n",
     "save_partition_data(valid_df.index, valid_data_fpath)\n",
+    "save_partition_data(soft_test_indices, soft_test_data_fpath)\n",
     "save_partition_data(test_df.index, test_data_fpath)"
    ]
   },
@@ -1094,7 +1119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 33,
    "id": "9db79da8",
    "metadata": {},
    "outputs": [
@@ -1104,7 +1129,7 @@
        "0.0"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1116,7 +1141,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 34,
    "id": "0dbb82a2",
    "metadata": {},
    "outputs": [
@@ -1126,7 +1151,7 @@
        "0.7119565217391305"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1139,7 +1164,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 35,
    "id": "ce3f97de",
    "metadata": {},
    "outputs": [
@@ -1149,7 +1174,7 @@
        "0.0"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/01_process/src/C_TrainTestSplits.md
+++ b/01_process/src/C_TrainTestSplits.md
@@ -72,6 +72,7 @@ try_n_test_partitions = 10000
 ```python
 train_data_fpath = out_dir + 'train_data.npz'
 valid_data_fpath = out_dir + 'valid_data.npz'
+soft_test_data_fpath = out_dir + 'soft_test_data.npz'
 test_data_fpath = out_dir + 'test_data.npz'
 ```
 
@@ -381,8 +382,20 @@ def save_partition_data(indices, fpath):
 ```
 
 ```python
+soft_test_indices = []
+for i in df.index:
+    if (i not in train_df.index) and (i not in valid_df.index) and (i not in test_df.index):
+        soft_test_indices.append(i)
+```
+
+```python
+assert (len(soft_test_indices) + train_df.shape[0] + valid_df.shape[0] + test_df.shape[0]) == df.shape[0]
+```
+
+```python
 save_partition_data(train_df.index, train_data_fpath)
 save_partition_data(valid_df.index, valid_data_fpath)
+save_partition_data(soft_test_indices, soft_test_data_fpath)
 save_partition_data(test_df.index, test_data_fpath)
 ```
 


### PR DESCRIPTION
Very small PR that I'm pushing through without review.

### What's different?

I added a few lines of code to implement the "soft" test sets discussed in https://github.com/jdiaz4302/lake_ice_prediction/pull/11

These are additional data that were discarded and thus not used for weight training or hyperparameter selection, but they are more similar to the training/validation set than the true test set (which has different lakes in different years). There ends up being two types of soft test data:

1. Data for lakes that were used during training but for years that were withheld for testing; I later abbreviate this as "TYTrL" (**T**est **Y**ears, **Tr**ain **L**akes).
3. Data for lakes that were withheld for testing but for years that were used during training; I later abbreviate this as "TrYTL" (**Tr**ain **Y**ears, **T**est **L**akes).

It was quickly verified (via initially saving to different file paths) that this does not change the existing training, validation or test sets. 

